### PR TITLE
Image package updated to latest version

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -6,7 +6,7 @@ import 'package:flutter_launcher_icons/custom_exceptions.dart';
 import 'package:flutter_launcher_icons/flutter_launcher_icons_config.dart';
 import 'package:flutter_launcher_icons/utils.dart';
 import 'package:flutter_launcher_icons/xml_templates.dart' as xml_template;
-import 'package:image/image.dart';
+import 'package:image/image.dart' hide decodeImageFile;
 import 'package:path/path.dart' as path;
 
 class AndroidIconTemplate {

--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -46,9 +46,9 @@ void createIcons(FlutterLauncherIconsConfig config, String? flavor) {
     return;
   }
   if (config.removeAlphaIOS) {
-    image.channels = Channels.rgb;
+    image.remapChannels(ChannelOrder.rgb);
   }
-  if (image.channels == Channels.rgba) {
+  if (image.hasAlpha) {
     print(
       '\nWARNING: Icons with alpha channel are not allowed in the Apple App Store.\nSet "remove_alpha_ios: true" to remove it.\n',
     );


### PR DESCRIPTION
1. Hide imageDecodeFile from image package import to avoid conflict in method name.
2. updated the process of removing alpha for iOS images as per the latest version.